### PR TITLE
Revert "push versions twice for issue 2587"

### DIFF
--- a/charts/example-cloud-connector/Makefile
+++ b/charts/example-cloud-connector/Makefile
@@ -73,7 +73,3 @@ updatebot/push-version:
 	@echo Doing updatebot push-version.....
 	cd ../../ && updatebot push-version --kind helm  $(RELEASE_ARTIFACT) $(RELEASE_VERSION)
 	cd ../../ && updatebot push-version --kind make  CONNECTOR_ACTIVITI_CLOUD_DEPENDENCIES_VERSION $(ACTIVITI_CLOUD_DEPENDENCIES_VERSION)
-	sleep $((RANDOM % 10))
-	cd ../../ && updatebot push-version --kind helm  $(RELEASE_ARTIFACT) $(RELEASE_VERSION)
-	cd ../../ && updatebot push-version --kind make  CONNECTOR_ACTIVITI_CLOUD_DEPENDENCIES_VERSION $(ACTIVITI_CLOUD_DEPENDENCIES_VERSION)
-	


### PR DESCRIPTION
Reverts Activiti/example-cloud-connector#133

Getting

```
sleep )
/bin/sh: -c: line 0: syntax error near unexpected token `)'
/bin/sh: -c: line 0: `sleep )'
make: *** [updatebot/push-version] Error 1
[Pipeline] }
ERROR: script returned exit code 2
```
The same thing is working on example-runtime-bundle and activiti-cloud-query so presumably something wrong in the whitespace