### PR TITLE
fix(versions): update Activiti/example-cloud-connector versions into master

### DIFF
--- a/charts/example-cloud-connector/requirements.yaml
+++ b/charts/example-cloud-connector/requirements.yaml
@@ -1,4 +1,5 @@
-dependencies: 
-- name: common
-  repository: https://activiti.github.io/activiti-cloud-charts/
-  version: 1.1.4
+---
+dependencies:
+- name: "common"
+  repository: "https://activiti.github.io/activiti-cloud-charts/"
+  version: "0.0.1"

--- a/charts/example-cloud-connector/requirements.yaml
+++ b/charts/example-cloud-connector/requirements.yaml
@@ -2,4 +2,4 @@
 dependencies:
 - name: "common"
   repository: "https://activiti.github.io/activiti-cloud-charts/"
-  version: "0.0.1"
+  version: "1.1.5"


### PR DESCRIPTION
[UpdateBot](https://github.com/jenkins-x/updatebot) pushed helm dependency: `common` to: `0.0.1`