### PR TITLE
fix(versions): update Activiti/example-cloud-connector versions into master

### DIFF
--- a/charts/example-cloud-connector/requirements.yaml
+++ b/charts/example-cloud-connector/requirements.yaml
@@ -2,4 +2,4 @@
 dependencies:
 - name: "common"
   repository: "https://activiti.github.io/activiti-cloud-charts/"
-  version: "1.1.5"
+  version: "1.1.6"

--- a/charts/example-cloud-connector/requirements.yaml
+++ b/charts/example-cloud-connector/requirements.yaml
@@ -2,4 +2,4 @@
 dependencies:
 - name: "common"
   repository: "https://activiti.github.io/activiti-cloud-charts/"
-  version: "1.1.6"
+  version: "1.1.7"


### PR DESCRIPTION
[UpdateBot](https://github.com/jenkins-x/updatebot) pushed helm dependency: `common` to: `1.1.6`