### PR TITLE
refactor(build): removed component scans configurations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,26 +43,6 @@
             <artifactId>activiti-cloud-starter-connector</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.activiti.cloud.common</groupId>
-            <artifactId>activiti-cloud-services-common-security-keycloak</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.activiti.cloud.common</groupId>
-            <artifactId>activiti-cloud-services-tracing</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.activiti.cloud.common</groupId>
-            <artifactId>activiti-cloud-services-logging</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>net.logstash.logback</groupId>
-            <artifactId>logstash-logback-encoder</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
This PR fixes Spring Boot bean override problems by removing component scans from configuration classes and adds missing @ConditionalOnMissingBean annotation on beans created in Activiti Runtime Spring Boot Auto-configurations

Depends on https://github.com/Activiti/activiti-cloud-notifications-service-graphql/pull/137

Fixes https://github.com/Activiti/Activiti/issues/1399