### PR TITLE
Kafka doesn't support special symbols in topic names

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 server.port=8080
 spring.application.name=example-connector
 
-spring.cloud.stream.bindings.exampleConnectorConsumer.destination=Example Connector
+spring.cloud.stream.bindings.exampleConnectorConsumer.destination=ExampleConnector
 spring.cloud.stream.bindings.exampleConnectorConsumer.contentType=application/json
 spring.cloud.stream.bindings.exampleConnectorConsumer.group=${spring.application.name}
 


### PR DESCRIPTION
Kafka doesn't support special symbols in topic names in example runtime boundle tests 