### PR TITLE
fix(versions): update Activiti/example-cloud-connector versions into master

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <version>7.1.0-SNAPSHOT</version>
   <name>Activiti Cloud :: Example Cloud Connector</name>
   <properties>
-    <activiti-cloud-connectors.version>7.1.140</activiti-cloud-connectors.version>
+    <activiti-cloud-connectors.version>7.1.141</activiti-cloud-connectors.version>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
[UpdateBot](https://github.com/jenkins-x/updatebot) pushed maven dependency: `org.activiti.cloud.connector:activiti-cloud-connectors-dependencies` to: `7.1.141`