### PR TITLE
fix(versions): update Activiti/example-cloud-connector versions

### DIFF
--- a/charts/activiti-cloud-connector/requirements.yaml
+++ b/charts/activiti-cloud-connector/requirements.yaml
@@ -2,4 +2,4 @@
 dependencies:
 - name: "common"
   repository: "https://activiti.github.io/activiti-cloud-helm-charts/"
-  version: "1.1.32"
+  version: "1.1.34"


### PR DESCRIPTION
[UpdateBot](https://github.com/jenkins-x/updatebot) pushed helm dependency: `common` to: `1.1.34`